### PR TITLE
Add wraparound tests for multi-res array

### DIFF
--- a/MyConsoleApp.Tests/CircularMultiResolutionArrayTests.cs
+++ b/MyConsoleApp.Tests/CircularMultiResolutionArrayTests.cs
@@ -28,14 +28,53 @@ public class CircularMultiResolutionArrayTests
 		Assert.AreEqual(2, arr[1, 1]);
 	}
 
-	[TestMethod]
-	public void PushMany()
-	{
-		var arr = new CircularMultiResolutionArray<int>(2, 3, 2);
-		for (int i = 0; i < 100; i++)
-		{
-			arr.PushFront(i);
-		}
-	}
+        [TestMethod]
+        public void PushMany()
+        {
+                var arr = new CircularMultiResolutionArray<int>(2, 3, 2);
+                for (int i = 0; i < 100; i++)
+                {
+                        arr.PushFront(i);
+                }
+        }
+
+        [TestMethod]
+        public void HighResolutionCyclesWhenCapacityExceeded()
+        {
+                var arr = new CircularMultiResolutionArray<int>(3, 4, 2);
+                for (int i = 1; i <= 5; i++)
+                {
+                        arr.PushFront(i);
+                }
+                Assert.AreEqual(3, arr.GetStartIndex(0));
+                Assert.AreEqual(5, arr[0, 0]);
+                Assert.AreEqual(2, arr[0, 3]);
+        }
+
+        [TestMethod]
+        public void MidResolutionCyclesWhenCapacityExceeded()
+        {
+                var arr = new CircularMultiResolutionArray<int>(3, 4, 2);
+                for (int i = 1; i <= 10; i++)
+                {
+                        arr.PushFront(i);
+                }
+                Assert.AreEqual(3, arr.GetStartIndex(1));
+                Assert.AreEqual(9, arr[1, 0]);
+                Assert.AreEqual(3, arr[1, 3]);
+        }
+
+        [TestMethod]
+        public void LowestResolutionCyclesWhenCapacityExceeded()
+        {
+                var arr = new CircularMultiResolutionArray<int>(3, 4, 2);
+                for (int i = 1; i <= 20; i++)
+                {
+                        arr.PushFront(i);
+                }
+                Assert.AreEqual(3, arr.GetStartIndex(2));
+                Assert.AreEqual(18, arr[2, 0]);
+                Assert.AreEqual(6, arr[2, 3]);
+        }
 
 }


### PR DESCRIPTION
## Summary
- add tests for wrapping when each resolution array cycles
- ensure coverage for highest, middle and lowest resolutions

## Testing
- `dotnet test MyConsoleApp.sln`
- `dotnet test MyConsoleApp.sln --no-build`

------
https://chatgpt.com/codex/tasks/task_e_68682d51c09883218fefca2626adad70