### PR TITLE
Add wraparound tests for multi-res array

### DIFF
--- a/MyConsoleApp.Tests/CircularMultiResolutionArrayTests.cs
+++ b/MyConsoleApp.Tests/CircularMultiResolutionArrayTests.cs
@@ -28,14 +28,75 @@ public class CircularMultiResolutionArrayTests
 		Assert.AreEqual(2, arr[1, 1]);
 	}
 
-	[TestMethod]
-	public void PushMany()
-	{
-		var arr = new CircularMultiResolutionArray<int>(2, 3, 2);
-		for (int i = 0; i < 100; i++)
-		{
-			arr.PushFront(i);
-		}
-	}
+        [TestMethod]
+        public void PushMany()
+        {
+                var arr = new CircularMultiResolutionArray<int>(2, 3, 2);
+                for (int i = 0; i < 100; i++)
+                {
+                        arr.PushFront(i);
+                }
+        }
+
+        [TestMethod]
+        public void HighResolutionCyclesWhenCapacityExceeded()
+        {
+                var arr = new CircularMultiResolutionArray<int>(3, 4, 2);
+                for (int i = 1; i <= 5; i++)
+                {
+                        arr.PushFront(i);
+                }
+                Assert.AreEqual(3, arr.GetStartIndex(0));
+                Assert.AreEqual(5, arr[0, 0]);
+                Assert.AreEqual(2, arr[0, 3]);
+        }
+
+        [TestMethod]
+        public void MidResolutionCyclesWhenCapacityExceeded()
+        {
+                var arr = new CircularMultiResolutionArray<int>(3, 4, 2);
+                for (int i = 1; i <= 10; i++)
+                {
+                        arr.PushFront(i);
+                }
+                Assert.AreEqual(3, arr.GetStartIndex(1));
+                Assert.AreEqual(9, arr[1, 0]);
+                Assert.AreEqual(3, arr[1, 3]);
+        }
+
+        [TestMethod]
+        public void LowestResolutionCyclesWhenCapacityExceeded()
+        {
+                var arr = new CircularMultiResolutionArray<int>(3, 4, 2);
+                for (int i = 1; i <= 20; i++)
+                {
+                        arr.PushFront(i);
+                }
+                Assert.AreEqual(3, arr.GetStartIndex(2));
+                Assert.AreEqual(18, arr[2, 0]);
+                Assert.AreEqual(6, arr[2, 3]);
+        }
+
+        [TestMethod]
+        public void OnItemAddedIsInvokedWithAddedValue()
+        {
+                var arr = new CircularMultiResolutionArray<int>(1, 2, 2);
+                int? added = null;
+                arr.OnItemAdded += i => added = i;
+                arr.PushFront(42);
+                Assert.AreEqual(42, added);
+        }
+
+        [TestMethod]
+        public void OnItemRemovedIsInvokedWhenItemIsOverwritten()
+        {
+                var arr = new CircularMultiResolutionArray<int>(1, 2, 2);
+                int? removed = null;
+                arr.OnItemRemoved += i => removed = i;
+                arr.PushFront(1);
+                arr.PushFront(2);
+                arr.PushFront(3); // overwrites 1
+                Assert.AreEqual(1, removed);
+        }
 
 }

--- a/MyConsoleApp/CircularMultiResolutionArray.cs
+++ b/MyConsoleApp/CircularMultiResolutionArray.cs
@@ -12,6 +12,10 @@ namespace MyConsoleApp
         private readonly int[] _starts;
         private readonly T[] _sums;
         private readonly int[] _counts;
+        private int _filledCount;
+
+        public event Action<T>? OnItemAdded;
+        public event Action<T>? OnItemRemoved;
 
         public int Partitions => _partitions;
         public int Size => _size;
@@ -30,6 +34,7 @@ namespace MyConsoleApp
             _starts = new int[partitions];
             _sums = new T[partitions];
             _counts = new int[partitions];
+            _filledCount = 0;
 
             for (int i = 0; i < partitions; i++)
             {
@@ -42,7 +47,37 @@ namespace MyConsoleApp
 
         public void PushFront(T item)
         {
-            PushToLevel(0, item);
+            int start = (_starts[0] - 1 + _size) % _size;
+            bool removed = false;
+            T removedValue = _arrays[0][start];
+            if (_filledCount == _size)
+            {
+                removed = true;
+            }
+            else
+            {
+                _filledCount++;
+            }
+
+            _starts[0] = start;
+            _arrays[0][start] = item;
+
+            _sums[0] += item;
+            _counts[0]++;
+
+            if (_counts[0] >= _increase)
+            {
+                T avg = _sums[0] / T.CreateChecked(_increase);
+                _sums[0] = T.Zero;
+                _counts[0] = 0;
+                PushToLevel(1, avg);
+            }
+
+            OnItemAdded?.Invoke(item);
+            if (removed)
+            {
+                OnItemRemoved?.Invoke(removedValue);
+            }
         }
 
         private void PushToLevel(int level, T item)


### PR DESCRIPTION
## Summary
- add tests for wrapping when each resolution array cycles
- ensure coverage for highest, middle and lowest resolutions
- implement `OnItemAdded` and `OnItemRemoved` events on `CircularMultiResolutionArray`
- test event invocation

## Testing
- `dotnet test MyConsoleApp.sln`
- `dotnet test MyConsoleApp.sln --no-build`

------
https://chatgpt.com/codex/tasks/task_e_68682d51c09883218fefca2626adad70