### PR TITLE
Add naive index access for circular array

### DIFF
--- a/MyConsoleApp.Tests/CircularMultiResolutionArrayTests.cs
+++ b/MyConsoleApp.Tests/CircularMultiResolutionArrayTests.cs
@@ -113,4 +113,35 @@ public class CircularMultiResolutionArrayTests
         arr.PushFront(3f); // triggers average 2
         Assert.AreEqual(2f, added);
     }
+
+    [TestMethod]
+    public void NaiveIndexAccessAndIndexStruct()
+    {
+        var arr = new CircularMultiResolutionArray<float>(2, 3, 2);
+        for (int i = 1; i <= 10; i++)
+        {
+            arr.PushFront(i);
+        }
+
+        Assert.AreEqual(10f, arr[1]);
+        Assert.AreEqual(9f, arr[2]);
+        Assert.AreEqual(8f, arr[3]);
+        Assert.AreEqual(7.5f, arr[4]);
+        Assert.AreEqual(5.5f, arr[5]);
+
+        var info3 = arr.GetIndex(3);
+        Assert.AreEqual(0, info3.Partition);
+        Assert.AreEqual(2, info3.PartitionIndex);
+        Assert.AreEqual(0, info3.Offset);
+
+        var info4 = arr.GetIndex(4);
+        Assert.AreEqual(1, info4.Partition);
+        Assert.AreEqual(1, info4.PartitionIndex);
+        Assert.AreEqual(1, info4.Offset);
+
+        var info5 = arr.GetIndex(5);
+        Assert.AreEqual(1, info5.Partition);
+        Assert.AreEqual(2, info5.PartitionIndex);
+        Assert.AreEqual(0, info5.Offset);
+    }
 }

--- a/MyConsoleApp/CircularMultiResolutionArray.cs
+++ b/MyConsoleApp/CircularMultiResolutionArray.cs
@@ -21,6 +21,50 @@ namespace MyConsoleApp
         public int Size => _size;
         public int Increase => _increase;
 
+        public readonly struct IndexInfo
+        {
+            public IndexInfo(int partition, int partitionIndex, int offset)
+            {
+                Partition = partition;
+                PartitionIndex = partitionIndex;
+                Offset = offset;
+            }
+
+            public int Partition { get; }
+            public int PartitionIndex { get; }
+            public int Offset { get; }
+        }
+
+        private int Pow(int exponent)
+        {
+            int result = 1;
+            for (int i = 0; i < exponent; i++)
+            {
+                result *= _increase;
+            }
+            return result;
+        }
+
+        public IndexInfo GetIndex(int naiveIndex)
+        {
+            if (naiveIndex <= 0)
+                throw new ArgumentOutOfRangeException(nameof(naiveIndex));
+
+            int idx = naiveIndex - 1;
+            for (int p = 0; p < _partitions; p++)
+            {
+                int factor = Pow(p);
+                int partitionIndex = idx / factor;
+                if (partitionIndex < _size)
+                {
+                    int offset = idx % factor;
+                    return new IndexInfo(p, partitionIndex, offset);
+                }
+            }
+
+            throw new ArgumentOutOfRangeException(nameof(naiveIndex));
+        }
+
         public CircularMultiResolutionArray(int partitions, int size, int increase)
         {
             if (partitions <= 0) throw new ArgumentOutOfRangeException(nameof(partitions));
@@ -104,6 +148,29 @@ namespace MyConsoleApp
                     throw new ArgumentOutOfRangeException(nameof(index));
                 int realIndex = (_starts[partition] + index) % _size;
                 return _arrays[partition][realIndex];
+            }
+        }
+
+        public T this[int naiveIndex]
+        {
+            get
+            {
+                var info = GetIndex(naiveIndex);
+                return this[info];
+            }
+        }
+
+        public T this[IndexInfo index]
+        {
+            get
+            {
+                if (index.Partition < 0 || index.Partition >= _partitions)
+                    throw new ArgumentOutOfRangeException(nameof(index));
+                if (index.PartitionIndex < 0 || index.PartitionIndex >= _size)
+                    throw new ArgumentOutOfRangeException(nameof(index));
+
+                int realIndex = (_starts[index.Partition] + index.PartitionIndex) % _size;
+                return _arrays[index.Partition][realIndex];
             }
         }
 


### PR DESCRIPTION
## Summary
- add a struct `IndexInfo` and helper methods to map naive indices
- expose two new indexers: access by naive index and by `IndexInfo`
- test naive index conversions and access

## Testing
- `dotnet test MyConsoleApp.sln --no-build` *(fails: CircularMultiResolutionSum not implemented)*

------
https://chatgpt.com/codex/tasks/task_e_686927f18edc83219889f70100803d89