### PR TITLE
Implement 0-based index access

### DIFF
--- a/MyConsoleApp.Tests/CircularMultiResolutionArrayTests.cs
+++ b/MyConsoleApp.Tests/CircularMultiResolutionArrayTests.cs
@@ -137,17 +137,17 @@ public class CircularMultiResolutionArrayTests
 
         var info3 = arr.GetIndex(3);
         Assert.AreEqual(1, info3.PartitionIndex);
-        Assert.AreEqual(0, info3.ItemIndex);
-        Assert.AreEqual(0, info3.Offset);
+        Assert.AreEqual(1, info3.ItemIndex);
+        Assert.AreEqual(1, info3.Offset);
 
         var info4 = arr.GetIndex(4);
         Assert.AreEqual(1, info4.PartitionIndex);
-        Assert.AreEqual(1, info4.ItemIndex);
+        Assert.AreEqual(2, info4.ItemIndex);
         Assert.AreEqual(0, info4.Offset);
 
         var info5 = arr.GetIndex(5);
         Assert.AreEqual(1, info5.PartitionIndex);
-        Assert.AreEqual(1, info5.ItemIndex);
+        Assert.AreEqual(2, info5.ItemIndex);
         Assert.AreEqual(1, info5.Offset);
     }
 

--- a/MyConsoleApp.Tests/CircularMultiResolutionSumTests.cs
+++ b/MyConsoleApp.Tests/CircularMultiResolutionSumTests.cs
@@ -133,7 +133,7 @@ public class CircularMultiResolutionSumTests
 
         for (int i = 0; i < 4; i++)
         {
-            var info = arr.GetIndex(i + 1);
+            var info = arr.GetIndex(i);
             Assert.AreEqual(sum[i], sum[info]);
         }
     }

--- a/MyConsoleApp/CircularMultiResolutionArray.cs
+++ b/MyConsoleApp/CircularMultiResolutionArray.cs
@@ -37,19 +37,18 @@ namespace MyConsoleApp
 
         public IndexInfo GetIndex(int naiveIndex)
         {
-            if (naiveIndex < 0 || naiveIndex >= _maxCount)
+            if (naiveIndex < 0 || naiveIndex >= _partitions * _size)
                 throw new ArgumentOutOfRangeException(nameof(naiveIndex));
 
-
-            int idx = naiveIndex - 1;
-            for (int partitionIndex = 0; partitionIndex < _partitions; partitionIndex++)
+            int idx = naiveIndex;
+            for (int partition = 0; partition < _partitions; partition++)
             {
-                int factor = Pow(partitionIndex);
+                int factor = Pow(partition);
                 int itemIndex = idx / factor;
                 if (itemIndex < _size)
                 {
                     int offset = idx % factor;
-                    return new IndexInfo(partitionIndex, itemIndex, offset);
+                    return new IndexInfo(partition, itemIndex, offset);
                 }
             }
 

--- a/MyConsoleApp/CircularMultiResolutionSum.cs
+++ b/MyConsoleApp/CircularMultiResolutionSum.cs
@@ -107,7 +107,7 @@ namespace MyConsoleApp
                 if (index < 0 || index >= _partitions * _size)
                     throw new ArgumentOutOfRangeException(nameof(index));
 
-                var info = _src.GetIndex(index + 1); // array uses 1-based naive index
+                var info = _src.GetIndex(index);
 
                 int partition = info.PartitionIndex;
                 int partIndex = info.ItemIndex;
@@ -119,7 +119,7 @@ namespace MyConsoleApp
                 T nextRun;
                 if (index + 1 < _partitions * _size)
                 {
-                    var nextInfo = _src.GetIndex(index + 2);
+                    var nextInfo = _src.GetIndex(index + 1);
                     int nextStart = _src.GetStartIndex(nextInfo.PartitionIndex);
                     nextRun = _runningSums[nextInfo.PartitionIndex][(nextStart + nextInfo.ItemIndex) % _size];
                 }


### PR DESCRIPTION
## Summary
- convert `CircularMultiResolutionArray.GetIndex` to compute from a zero-based naive index
- correct index mapping expectations in CMRA and CMRS tests

## Testing
- `dotnet test --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_68694754138883219b9ea4a2969f6306