### PR TITLE
Implement weighted sum counter reset

### DIFF
--- a/MyConsoleApp.Tests/CircularMultiResolutionWeightedSumTests.cs
+++ b/MyConsoleApp.Tests/CircularMultiResolutionWeightedSumTests.cs
@@ -1,0 +1,46 @@
+namespace MyConsoleApp.Tests;
+
+[TestClass]
+public class CircularMultiResolutionWeightedSumTests
+{
+    [TestMethod]
+    public void HarmonicSequence_WeightedSumEqualsItemCount()
+    {
+        var arr = new CircularMultiResolutionArray<float>(1, 8, 2);
+        var weighted = new CircularMultiResolutionWeightedSum<float>(arr, 2, 8, 2);
+
+        for (int n = 1; n <= 5; n++)
+        {
+            arr.PushFront(1f / n);
+            Assert.AreEqual(n, weighted[weighted.GetIndex(0)], 1e-4, $"After {n} items");
+        }
+    }
+
+    [TestMethod]
+    public void CountCappedAfterReset()
+    {
+        var arr = new CircularMultiResolutionArray<float>(1, 8, 2);
+        var weighted = new CircularMultiResolutionWeightedSum<float>(arr, 2, 8, 2);
+        for (int i = 0; i < weighted.MaxSize + 5; i++)
+        {
+            arr.PushFront(1f);
+        }
+
+        Assert.AreEqual(weighted.MaxSize, weighted.Count);
+    }
+
+    [TestMethod]
+    public void WeightedSumHandlesRemovalGracefully()
+    {
+        var arr = new CircularMultiResolutionArray<float>(1, 8, 2);
+        var weighted = new CircularMultiResolutionWeightedSum<float>(arr, 2, 8, 2);
+
+        for (int i = 0; i < weighted.MaxSize + 4; i++)
+        {
+            arr.PushFront(1f);
+        }
+
+        Assert.AreEqual(weighted.MaxSize, weighted.Count);
+        Assert.IsTrue(weighted[weighted.GetIndex(0)] > 0f);
+    }
+}

--- a/MyConsoleApp/CircularMultiResolutionWeightedSum.cs
+++ b/MyConsoleApp/CircularMultiResolutionWeightedSum.cs
@@ -1,0 +1,95 @@
+using System.Numerics;
+
+namespace MyConsoleApp
+{
+    public class CircularMultiResolutionWeightedSum<T> : CircularMultiResolutionBase<T> where T : INumber<T>
+    {
+        private readonly ICMRObject<T> _src;
+        private long _xCounter = 0;
+        private T _runningWeightedSum = T.Zero;
+        private T _runningSum = T.Zero;
+        private readonly T _runningWeightedSumMaxBeforeReset;
+
+        public CircularMultiResolutionWeightedSum(ICMRObject<T> src, int partitionCount, int partitionSize, int magnitudeIncrease, double anticipatedMaxItemValue = 5000)
+            : base(partitionCount, partitionSize, magnitudeIncrease)
+        {
+            _src = src;
+            // anticipate larger values due to weighting by x
+            _runningWeightedSumMaxBeforeReset = T.CreateTruncating(anticipatedMaxItemValue * _maxSize * _maxSize * 2d);
+            src.SubscribeValueAdded(OnPushFront);
+        }
+
+        private void OnPushFront()
+        {
+            _xCounter++;
+            T value = _src.First();
+            _runningSum += value;
+            _runningWeightedSum += T.CreateTruncating(_xCounter) * value;
+
+            for (int i = 0; i < _partitionCount; i++)
+            {
+                if (_countModLast % _modulos[i] == 0)
+                {
+                    _removed[i] = _partitions[i][_cursors[i]];
+                    _partitions[i][_cursors[i]] = _runningWeightedSum;
+                    _cursors[i] = (_cursors[i] + 1) % _partitionSize;
+                }
+                else
+                {
+                    break;
+                }
+            }
+
+            IncrementModuloCount();
+            AdvanceCounters(-1);
+
+            if (_runningWeightedSum >= _runningWeightedSumMaxBeforeReset)
+            {
+                ApplyRemoved();
+            }
+
+            ResetCounterIfNeeded();
+
+            OnValueAdded.Invoke();
+        }
+
+        private void ApplyRemoved()
+        {
+            T removedBase = _removed[_partitionCount - 1];
+            for (int i = 0; i < _partitionCount; i++)
+            {
+                for (int j = 0; j < _partitionSize; j++)
+                {
+                    _partitions[i][j] -= removedBase;
+                }
+            }
+            _removed[_partitionCount - 1] = T.Zero;
+        }
+
+        protected override (int offset, int maxOffset) ComputeOffset(int partitionIndex, int itemOffset)
+        {
+            int selectedOffset = itemOffset - _offsets[partitionIndex];
+            return (selectedOffset, _modulos[partitionIndex]);
+        }
+
+        protected override T PostProcess(T value) => value - _removed[_partitionCount - 1];
+
+        private void ResetCounterIfNeeded()
+        {
+            if (_xCounter < _maxSize)
+                return;
+
+            T correction = T.CreateTruncating(_maxSize) * _runningSum;
+            _runningWeightedSum -= correction;
+            for (int i = 0; i < _partitionCount; i++)
+            {
+                _removed[i] -= correction;
+                for (int j = 0; j < _partitionSize; j++)
+                {
+                    _partitions[i][j] -= correction;
+                }
+            }
+            _xCounter -= _maxSize;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- track running sum in `CircularMultiResolutionWeightedSum`
- reset weighted sum state when the x-counter exceeds the buffer size
- add tests covering counter reset and removal handling

## Testing
- `dotnet test ./MyConsoleApp.Tests/MyConsoleApp.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_687180f232148321aa63a4ffe28852cd